### PR TITLE
Enable aggregation layer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,10 @@ kube_apiserver_keyfile: /path
 kube_apiserver_cafile: /path
 kube_apiserver_client_ca: /path
 
+kube_apiserver_request_header_client_ca: /path
+kube_apiserver_request_header_certfile: /path
+kube_apiserver_request_header_keyfile: /path
+
 # Generate a new pem key with
 # openssl req -x509 -sha256 -nodes -days 365000 -newkey rsa:4096 -keyout key -out cert
 # and place the content of the files in the variables

--- a/templates/kube-apiserver.j2
+++ b/templates/kube-apiserver.j2
@@ -19,4 +19,12 @@ DAEMON_ARGS="                                                               \
 --service-account-signing-key-file={{ kube_apiserver_cafile | dirname }}/service_account_key.pem \
 --service-account-key-file={{ kube_apiserver_cafile | dirname }}/service_account_cert.pem \
 --service-account-issuer=kubernetes                                         \
+--requestheader-client-ca-file={{ kube_apiserver_request_header_client_ca }} \
+--requestheader-allowed-names=""                                            \
+--requestheader-extra-headers-prefix=X-Remote-Extra-                        \
+--requestheader-group-headers=X-Remote-Group                                \
+--requestheader-username-headers=X-Remote-User                              \
+--proxy-client-cert-file={{ kube_apiserver_request_header_certfile }}       \
+--proxy-client-key-file={{ kube_apiserver_request_header_keyfile }}         \
+--enable-aggregator-routing=true \
 "


### PR DESCRIPTION
Aggregation layer is required to extend the kube-apiserver with
additional APIs such as metrics-server